### PR TITLE
fix overwrite logic

### DIFF
--- a/R/download_bbs.R
+++ b/R/download_bbs.R
@@ -92,6 +92,8 @@ download_bbs <-
         if(choice==1) overwrite.bbs <- TRUE
         if(choice==2) overwrite.bbs <- FALSE
         rm(choice)
+    }else{
+      overwrite.bbs <- FALSE
     }
     
     #  If files do not exist OR overwrite ==TRUE, 


### PR DESCRIPTION
Running `test-download_bbs.R` in a clean session gives me an error:

> Error in if (overwrite.bbs | length(list.files(data.dir)) == 0) { : 
  argument is of length zero

because `overwrite.bbs` is `NULL`. This PR sets it to FALSE if no file conflicts are detected.